### PR TITLE
Use uint32_t instead int in comparisons

### DIFF
--- a/csum-gcrypt.c
+++ b/csum-gcrypt.c
@@ -60,7 +60,7 @@ int init_hash(void)
 
 void debug_print_digest(FILE *stream, unsigned char *digest)
 {
-	int i;
+	uint32_t i;
 
 	for (i = 0; i < digest_len; i++)
 		fprintf(stream, "%.2x", digest[i]);
@@ -75,7 +75,7 @@ struct running_checksum *start_running_checksum(void)
 {
 	struct running_checksum *c = calloc(1, sizeof(struct running_checksum));
 
-	if (c) {	
+	if (c) {
 		if (gcry_md_open(&c->hd, HASH_FUNC, 0) != GPG_ERR_NO_ERROR) {
 			free(c);
 			c = NULL;

--- a/util.c
+++ b/util.c
@@ -85,7 +85,7 @@ uint64_t parse_size(char *s)
 static char *size_strs[] = { "", "K", "M", "G", "T", "P", "E"};
 int pretty_size_snprintf(uint64_t size, char *str, size_t str_bytes)
 {
-	int num_divs = 0;
+	uint32_t num_divs = 0;
 	float fraction;
 
 	if (str_bytes == 0)


### PR DESCRIPTION
Signed-off-by: Timofey Titovets nefelim4ag@gmail.com
