### PR TITLE
Use uint32_t instead int in comparisons

### DIFF
--- a/csum-mhash.c
+++ b/csum-mhash.c
@@ -26,7 +26,7 @@ static MHASH td;
 
 #define	HASH_FUNC	MHASH_SHA256
 
-unsigned int digest_len = 0;
+uint32_t digest_len = 0;
 
 void checksum_block(char *buf, int len, unsigned char *digest)
 {
@@ -50,7 +50,7 @@ int init_hash(void)
 
 void debug_print_digest(FILE *stream, unsigned char *digest)
 {
-	int i;
+	uint32_t i;
 
 	for (i = 0; i < digest_len; i++)
 		fprintf(stream, "%.2x", digest[i]);

--- a/serialize.c
+++ b/serialize.c
@@ -279,7 +279,8 @@ static int read_hash(int fd, struct block_hash *b)
 
 static int read_one_file(int fd, struct hash_tree *tree)
 {
-	int ret, i;
+	int ret;
+	uint32_t i;
 	struct file_info finfo;
 	struct block_hash bhash;
 	struct filerec *file;
@@ -334,7 +335,8 @@ static int read_header(int fd, struct hash_file_header *h)
 int read_hash_tree(char *filename, struct hash_tree *tree,
 		   unsigned int *block_size)
 {
-	int ret, fd, i;
+	int ret, fd;
+	uint32_t i;
 	struct hash_file_header h;
 
 	fd = open(filename, O_RDONLY);


### PR DESCRIPTION
Signed-off-by: Timofey Titovets nefelim4ag@gmail.com
