### PR TITLE
Default --lookup-extents option value to no again

### DIFF
--- a/duperemove.c
+++ b/duperemove.c
@@ -66,7 +66,7 @@ static int write_hashes = 0;
 static int read_hashes = 0;
 static char *serialize_fname = NULL;
 unsigned int io_threads;
-int do_lookup_extents = 1;
+int do_lookup_extents = 0;
 
 int fancy_status = 0;
 
@@ -187,7 +187,7 @@ static int parse_options(int argc, char **argv)
 				return EINVAL;
 			break;
 		case LOOKUP_EXTENTS_OPTION:
-			do_lookup_extents = parse_yesno_option(optarg, 1);
+			do_lookup_extents = parse_yesno_option(optarg, 0);
 			break;
 		case ONE_FILESYSTEM_OPTION:
 		case 'x':


### PR DESCRIPTION
The default for `--lookup-extents` was set to `no` in e1c8950b2e09fb3ac810a5f48b581e4b350c7ef9, but regressed to `yes` in 1b77385f1ec28a145e6a2305561d149a7e1eb1e1.

The commit in this PR sets this back to "no" to match the information in `duperemove.8`
