### PR TITLE
Allow reading a list of file names from standard input

### DIFF
--- a/duperemove.8
+++ b/duperemove.8
@@ -45,8 +45,9 @@ estimate is calculated by comparing the total amount of shared bytes
 in each file before and after the dedupe.
 
 .SH "OPTIONS"
-\fIfiles\fR can refer to a list of regular files and directories. If a
-directory is specified, all regular files within it will also be
+\fIfiles\fR can refer to a list of regular files and directories or be
+a hyphen (-) to read them from standard input.
+If a directory is specified, all regular files within it will also be
 scanned.
 
 .TP


### PR DESCRIPTION
This PR adds the ability to read a list of file names from standard input if the only filename specified on the command line is `-`.  This allows lists of files longer than the maximum command line length to be passed to duperemove and makes it easier to use a list of files piped from another command.

I've also included another commit which fixes a couple of small typos in the `duperemove` man page which I noticed while I was updating it.
