### PR TITLE
fix build on ubuntu and enable optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VER=0.10-dev
 RELEASE=v$(VER)
 
 CC = gcc
-CFLAGS = -Wall -ggdb -lm
+CFLAGS = -Wall -ggdb
 
 MANPAGES=duperemove.8 btrfs-extent-same.8 hashstats.8 show-shared-extents.8
 
@@ -45,7 +45,7 @@ glib_LIBS=$(shell pkg-config --libs glib-2.0)
 
 override CFLAGS += -D_FILE_OFFSET_BITS=64 -DVERSTRING=\"$(RELEASE)\" \
 	$(hash_CFLAGS) $(glib_CFLAGS) -rdynamic
-LIBRARY_FLAGS += $(hash_LIBS) $(glib_LIBS)
+LIBRARY_FLAGS += $(hash_LIBS) $(glib_LIBS) -lm
 
 # make C=1 to enable sparse
 ifdef C

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VER=0.10-dev
 RELEASE=v$(VER)
 
 CC = gcc
-CFLAGS = -Wall -ggdb
+CFLAGS = -Wall -ggdb -O2
 
 MANPAGES=duperemove.8 btrfs-extent-same.8 hashstats.8 show-shared-extents.8
 


### PR DESCRIPTION
fix link error on ubuntu based platforms

also enable compile optimizations by default in the build, I did not expect the default make to build a debug build, only noticed much later it when looking at the perf profile of the slow running program.