### PR TITLE
Don't dedup already deduped extents

### DIFF
--- a/filerec.c
+++ b/filerec.c
@@ -538,6 +538,7 @@ int filerec_count_shared(struct filerec *file, uint64_t start, uint64_t len,
 		 */
 		fiemap->fm_length = ~0ULL;
 		fiemap->fm_extent_count = count;
+		fiemap->fm_start = start;
 		rc = ioctl(file->fd, FS_IOC_FIEMAP, (unsigned long) fiemap);
 		if (rc < 0)
 			return errno;
@@ -607,7 +608,8 @@ int filerec_count_shared(struct filerec *file, uint64_t start, uint64_t len,
 //				" flags: 0x%x\n",
 //				loff, ext_len, fm_ext[i].fe_flags);
 
-			if (fm_ext[i].fe_flags & FIEMAP_EXTENT_SHARED)
+			if (!(fm_ext[i].fe_flags & FIEMAP_EXTENT_DELALLOC)
+				&& fm_ext[i].fe_flags & FIEMAP_EXTENT_SHARED)
 				*shared_bytes += ext_len;
 		}
 

--- a/filerec.h
+++ b/filerec.h
@@ -49,7 +49,7 @@ int filerec_open_once(struct filerec *file, int write,
 void filerec_close_open_list(struct open_once *open_files);
 
 int filerec_count_shared(struct filerec *file, uint64_t start, uint64_t len,
-			 uint64_t *shared_bytes);
+			 uint64_t *shared_bytes, uint64_t *poff);
 
 /*
  * Track unique filerecs in a tree. Two places in the code use this:

--- a/results-tree.c
+++ b/results-tree.c
@@ -46,6 +46,7 @@ static struct extent *alloc_extent(struct filerec *file, uint64_t loff)
 		rb_init_node(&e->e_node);
 		e->e_file = file;
 		e->e_loff = loff;
+		e->e_poff = 0;
 	}
 	return e;
 }

--- a/results-tree.c
+++ b/results-tree.c
@@ -243,7 +243,7 @@ static uint64_t extent_len(struct extent *extent)
 	return extent->e_parent->de_len;
 }
 
-static unsigned int remove_extent(struct results_tree *res, struct extent *extent)
+unsigned int remove_extent(struct results_tree *res, struct extent *extent)
 {
 	struct dupe_extents *p = extent->e_parent;
 	struct rb_node *n;

--- a/results-tree.h
+++ b/results-tree.h
@@ -31,6 +31,8 @@ struct extent	{
 	/* Each file keeps a list of it's own dupes. This makes it
 	 * easier to remove overlapping duplicates. */
 	struct list_head	e_file_extents; /* filerec->extent_list */
+
+	uint64_t		e_poff;
 };
 
 /* endoff is NOT inclusive! */

--- a/results-tree.h
+++ b/results-tree.h
@@ -45,4 +45,5 @@ void remove_overlapping_extents(struct results_tree *res, struct filerec *file);
 void init_results_tree(struct results_tree *res);
 void dupe_extents_free(struct dupe_extents *dext, struct results_tree *res);
 
+unsigned int remove_extent(struct results_tree *res, struct extent *extent);
 #endif /* __RESULTS_TREE__ */

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -212,7 +212,7 @@ static int dedupe_extent_list(struct dupe_extents *dext, uint64_t *fiemap_bytes,
 	while(clean_deduped(dext));
 
 	if (list_empty(&dext->de_extents))
-		return 0;
+		goto out;
 
 	list_for_each_entry(extent, &dext->de_extents, e_list) {
 		vprintf("%s\tstart block: %llu (%llu)\n",
@@ -363,9 +363,11 @@ static int dedupe_worker(struct dupe_extents *dext,
 		return ret;
 	}
 
-	g_mutex_lock(&mutex);
-	dupe_extents_free(dext, results_tree);
-	g_mutex_unlock(&mutex);
+	if (!list_empty(&dext->de_extents)) {
+		g_mutex_lock(&mutex);
+		dupe_extents_free(dext, results_tree);
+		g_mutex_unlock(&mutex);
+	}
 
 	g_mutex_lock(&dedupe_counts_mutex);
 	counts->fiemap_bytes += fiemap_bytes;

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -125,7 +125,7 @@ static void add_shared_extents(struct dupe_extents *dext, uint64_t *shared)
 			continue;
 
 		ret = filerec_count_shared(file, extent->e_loff, dext->de_len,
-					   shared);
+					   shared, &(extent->e_poff));
 		if (ret) {
 			fprintf(stderr, "%s: fiemap error %d: %s\n",
 				extent->e_file->filename, ret, strerror(ret));


### PR DESCRIPTION
Most of deduped extents can be skip by comparing the physical offset of them.
Before processing a dupe_extents list, we compare all entries and remove the same one.

The patch trades the ioctl cost for a small userspace processing cost.