### PR TITLE
Skip files that are smaller than bsize

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -200,6 +200,11 @@ int add_file(const char *name, int dirfd)
 		goto out;
 	}
 
+	if (st.st_size < blocksize) {
+		fprintf(stderr, "Skipping too small file %s\n", path);
+		goto out;
+	}
+
 	ret = faccessat(dirfd, name, R_OK, 0);
 	if (ret) {
 		fprintf(stderr, "Error %d: %s while accessing file %s. "


### PR DESCRIPTION
Fix segfault introduced by the check, see e56ba0dcff3a9273607de43de83d2e710d7cf7e6

Signed-off-by: Jack Kenrick <github@jack.fr.eu.org>