### PR TITLE
Ensure files are open before issuing deduplication iotcl

### DIFF
--- a/dedupe.c
+++ b/dedupe.c
@@ -309,7 +309,10 @@ int dedupe_extents(struct dedupe_ctxt *ctxt)
 		populate_dedupe_request(ctxt, ctxt->same);
 
 retry:
+		if (filerec_open(ctxt->ioctl_file, 0))
+			break;
 		ret = btrfs_extent_same(ctxt->ioctl_file->fd, ctxt->same);
+		filerec_close(ctxt->ioctl_file);
 		if (ret)
 			break;
 

--- a/dedupe.c
+++ b/dedupe.c
@@ -144,7 +144,10 @@ static unsigned int get_fs_blocksize(struct filerec *file)
 	int ret;
 	struct statfs fs;
 
+        if (filerec_open(file, 0))
+		return 0;
 	ret = fstatfs(file->fd, &fs);
+        filerec_close(file);
 	if (ret)
 		return 0;
 	return fs.f_bsize;


### PR DESCRIPTION
I think that this will help with issue #64. There are a couple of places where we were accessing an invalid FD.

I don't understand enough about the refcounted file handles to know why (or whether) these files should have been closed, but this gets me running again.