### PR TITLE
fiemap_flags_str: return "" if flags == 0

### DIFF
--- a/filerec.c
+++ b/filerec.c
@@ -643,6 +643,7 @@ static char *fiemap_flags_str(unsigned long long flags)
 	int written = 0;
 	char *str = flagstr;
 
+        *str = '\0';
 	if (flags) {
 		written = snprintf(str, size, "(");
 		str += written;


### PR DESCRIPTION
I was getting odd output from show-shared-extents, e.g.
(fiemap) [0] fe_logical: [snip] , fe_flags: 0x2000 (shared )
(fiemap) [1] fe_logical: [snip], fe_flags: 0x2000 (shared )
(fiemap) [2] fe_logical: [snip], fe_flags: 0x0 (shared )

Notice that final line: 0x0 (shared).

This patch fixes it.
