### PR TITLE
btrfs-extent-same: Fix file mode of deduplicated extents

### DIFF
--- a/btrfs-extent-same.c
+++ b/btrfs-extent-same.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 	for (i = 0; i < same->dest_count; i++) {
 		destf = argv[4 + (i * 2)];
 
-		ret = open(destf, O_RDONLY);
+		ret = open(destf, O_WRONLY);
 		if (ret < 0) {
 			ret = errno;
 			fprintf(stderr, "Could not open file %s: (%d) %s\n",


### PR DESCRIPTION
This allows `btrfs-extent-same` to work without root (at least on my 4.4.1 kernel).