### PR TITLE
Fix includes for musl, deactivate backtrace on non-glibc targets.

### DIFF
--- a/util.c
+++ b/util.c
@@ -24,7 +24,9 @@
 #include <stdint.h>
 #include <ctype.h>
 #include <inttypes.h>
+#ifdef __GLIBC__
 #include <execinfo.h>
+#endif
 #include <sys/time.h>
 
 #include "debug.h"
@@ -125,12 +127,14 @@ void print_stack_trace(void)
 	char **messages = (char **)NULL;
 	int i, trace_size = 0;
 
+#ifdef __GLIBC__
 	trace_size = backtrace(trace, 16);
 	messages = backtrace_symbols(trace, trace_size);
 	printf("[stack trace follows]\n");
 	for (i=0; i < trace_size; i++)
 		printf("%s\n", messages[i]);
 	free(messages);
+#endif
 }
 
 void record_start(struct elapsed_time *e, const char *name)

--- a/util.h
+++ b/util.h
@@ -19,6 +19,7 @@
 #define	__UTIL_H__
 
 #include <stdint.h>
+#include <sys/time.h>
 
 /* controlled by user options, turns pretty print on if true. */
 extern int human_readable;


### PR DESCRIPTION
This PR fixes some problems during compilation on musl libc.