### PR TITLE
Improve scanning phase

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -77,11 +77,17 @@ static int create_tables(sqlite3 *db)
 	if (ret)
 		goto out;
 
+out:
+	return ret;
+}
+
+int create_indexes(sqlite3 *db)
+{
+	int ret;
 #define	CREATE_DIGEST_INDEX						\
 "create index idx_digest on hashes(digest);"
-	ret = sqlite3_exec(db, CREATE_DIGEST_INDEX, NULL, db, &errorstr);
+	ret = sqlite3_exec(db, CREATE_DIGEST_INDEX, NULL, NULL, NULL);
 
-out:
 	return ret;
 }
 

--- a/dbfile.c
+++ b/dbfile.c
@@ -263,16 +263,9 @@ int dbfile_sync_config(unsigned int block_size)
 	return ret;
 }
 
-static int __dbfile_count_rows(sqlite3_stmt *stmt, const char *rowid,
-			       uint64_t *num)
+static int __dbfile_count_rows(sqlite3_stmt *stmt, uint64_t *num)
 {
 	int ret;
-
-	ret = sqlite3_bind_text(stmt, 1, rowid, -1, SQLITE_STATIC);
-	if (ret) {
-		perror_sqlite(ret, "retrieving count from table (bind)");
-		return ret;
-	}
 
 	ret = sqlite3_step(stmt);
 	if (ret != SQLITE_ROW) {
@@ -294,12 +287,12 @@ static int dbfile_count_rows(sqlite3 *db, uint64_t *num_hashes,
 	sqlite3_stmt *stmt = NULL;
 
 	if (num_hashes) {
-#define COUNT_HASHES "select COUNT(?1) from hashes;"
+#define COUNT_HASHES "select COUNT(*) from hashes;"
 		ret = sqlite3_prepare_v2(db, COUNT_HASHES, -1, &stmt, NULL);
 		if (ret)
 			goto out;
 
-		ret = __dbfile_count_rows(stmt, "digest", num_hashes);
+		ret = __dbfile_count_rows(stmt, num_hashes);
 		if (ret)
 			goto out;
 
@@ -308,12 +301,12 @@ static int dbfile_count_rows(sqlite3 *db, uint64_t *num_hashes,
 	}
 
 	if (num_files) {
-#define COUNT_FILES "select COUNT(?1) from files;"
+#define COUNT_FILES "select COUNT(*) from files;"
 		ret = sqlite3_prepare_v2(db, COUNT_FILES, -1, &stmt, NULL);
 		if (ret)
 			goto out;
 
-		ret = __dbfile_count_rows(stmt, "filename", num_files);
+		ret = __dbfile_count_rows(stmt, num_files);
 		if (ret)
 			goto out;
 

--- a/dbfile.c
+++ b/dbfile.c
@@ -61,20 +61,20 @@ static int create_tables(sqlite3 *db)
 
 #define CREATE_TABLE_CONFIG	\
 "CREATE TABLE config(keyname TEXT PRIMARY KEY NOT NULL, keyval BLOB);"
-	ret = sqlite3_exec(db, CREATE_TABLE_CONFIG, NULL, db, &errorstr);
+	ret = sqlite3_exec(db, CREATE_TABLE_CONFIG, NULL, NULL, &errorstr);
 	if (ret)
 		goto out;
 
 #define	CREATE_TABLE_FILES	\
 "CREATE TABLE files(filename TEXT PRIMARY KEY NOT NULL, ino INTEGER, "\
 "subvol INTEGER, size INTEGER, blocks INTEGER);"
-	ret = sqlite3_exec(db, CREATE_TABLE_FILES, NULL, db, &errorstr);
+	ret = sqlite3_exec(db, CREATE_TABLE_FILES, NULL, NULL, &errorstr);
 	if (ret)
 		goto out;
 
 #define	CREATE_TABLE_HASHES					\
 "CREATE TABLE hashes(digest BLOB KEY NOT NULL, ino INTEGER, subvol INTEGER, loff INTEGER, flags INTEGER);"
-	ret = sqlite3_exec(db, CREATE_TABLE_HASHES, NULL, db, &errorstr);
+	ret = sqlite3_exec(db, CREATE_TABLE_HASHES, NULL, NULL, &errorstr);
 	if (ret)
 		goto out;
 
@@ -521,7 +521,7 @@ int dbfile_write_hashes(sqlite3 *db, struct filerec *file, uint64_t nb_hash,
 		sqlite3_reset(stmt);
 	}
 
-	ret = sqlite3_exec(db, "COMMIT TRANSACTION", NULL, db, &errorstr);
+	ret = sqlite3_exec(db, "COMMIT TRANSACTION", NULL, NULL, &errorstr);
 	if (ret) {
 		perror_sqlite(ret, "committing transaction");
 		sqlite3_free(errorstr);

--- a/dbfile.c
+++ b/dbfile.c
@@ -57,24 +57,23 @@ static int debug_print_cb(void *priv, int argc, char **argv, char **column)
 static int create_tables(sqlite3 *db)
 {
 	int ret;
-	char *errorstr = NULL;
 
 #define CREATE_TABLE_CONFIG	\
 "CREATE TABLE config(keyname TEXT PRIMARY KEY NOT NULL, keyval BLOB);"
-	ret = sqlite3_exec(db, CREATE_TABLE_CONFIG, NULL, NULL, &errorstr);
+	ret = sqlite3_exec(db, CREATE_TABLE_CONFIG, NULL, NULL, NULL);
 	if (ret)
 		goto out;
 
 #define	CREATE_TABLE_FILES	\
 "CREATE TABLE files(filename TEXT PRIMARY KEY NOT NULL, ino INTEGER, "\
 "subvol INTEGER, size INTEGER, blocks INTEGER);"
-	ret = sqlite3_exec(db, CREATE_TABLE_FILES, NULL, NULL, &errorstr);
+	ret = sqlite3_exec(db, CREATE_TABLE_FILES, NULL, NULL, NULL);
 	if (ret)
 		goto out;
 
 #define	CREATE_TABLE_HASHES					\
 "CREATE TABLE hashes(digest BLOB KEY NOT NULL, ino INTEGER, subvol INTEGER, loff INTEGER, flags INTEGER);"
-	ret = sqlite3_exec(db, CREATE_TABLE_HASHES, NULL, NULL, &errorstr);
+	ret = sqlite3_exec(db, CREATE_TABLE_HASHES, NULL, NULL, NULL);
 	if (ret)
 		goto out;
 
@@ -83,9 +82,6 @@ static int create_tables(sqlite3 *db)
 	ret = sqlite3_exec(db, CREATE_DIGEST_INDEX, NULL, db, &errorstr);
 
 out:
-
-	sqlite3_free(errorstr);
-
 	return ret;
 }
 

--- a/dbfile.c
+++ b/dbfile.c
@@ -85,7 +85,7 @@ int create_indexes(sqlite3 *db)
 {
 	int ret;
 #define	CREATE_DIGEST_INDEX						\
-"create index idx_digest on hashes(digest);"
+"create index if not exists idx_digest on hashes(digest);"
 	ret = sqlite3_exec(db, CREATE_DIGEST_INDEX, NULL, NULL, NULL);
 
 	return ret;

--- a/dbfile.h
+++ b/dbfile.h
@@ -24,7 +24,7 @@ int create_indexes(sqlite3 *db);
  * Load hashes into hash_tree only if they have a duplicate in the db.
  * The extent search is later run on the resulting hash_tree.
  */
-int dbfile_load_hashes(struct hash_tree *scan_tree);
+int dbfile_load_hashes(struct hash_tree *hash_tree);
 
 /*
  * Following are used during file scan stage to get our hashes into

--- a/dbfile.h
+++ b/dbfile.h
@@ -18,14 +18,7 @@ struct hash_tree;
 struct hash_file_header;
 struct rb_root;
 
-/*
- * Scans hashes by digest, adding each one to our bloom filter. If we
- * find a duplicate, it is inserted into d_tree.
- *
- * This effectively does 'scan #1' for us when we're loading from a
- * dbfile instead of doing a file scan.
- */
-int dbfile_populate_hashes(struct rb_root *d_tree);
+int create_indexes(sqlite3 *db);
 
 /*
  * Load hashes into hash_tree only if they have a duplicate in the db.

--- a/dbfile.h
+++ b/dbfile.h
@@ -16,8 +16,6 @@ int dbfile_sync_config(unsigned int block_size);
 
 struct hash_tree;
 struct hash_file_header;
-/* Used only by hashstats, will load *all* hashes into 'hash_tree' */
-int dbfile_read_all_hashes(struct hash_tree *tree);
 struct rb_root;
 
 /*

--- a/duperemove.c
+++ b/duperemove.c
@@ -402,6 +402,8 @@ int main(int argc, char **argv)
 		goto out;
 	}
 
+	create_indexes(dbfile_get_handle());
+
 	/*
 	 * File scan from above can cause quite a bit of output, flush
 	 * here in case of logfile.

--- a/duperemove.c
+++ b/duperemove.c
@@ -373,7 +373,7 @@ int main(int argc, char **argv)
 		ret = dbfile_create(serialize_fname);
 		if (ret)
 			break;
-		ret = populate_tree_swap();
+		ret = populate_tree();
 		break;
 	case H_READ:
 		ret = dbfile_open(serialize_fname);

--- a/duperemove.c
+++ b/duperemove.c
@@ -64,12 +64,11 @@ static int version_only = 0;
 static int fdupes_mode = 0;
 
 static enum {
-	H_NONE = 0,
 	H_READ,
 	H_WRITE,
 	H_UPDATE,
-} use_hashfile = H_NONE;
-static char *serialize_fname = NULL;
+} use_hashfile = H_UPDATE;
+static char *serialize_fname = ":memory:";
 unsigned int io_threads;
 int do_lookup_extents = 0;
 
@@ -334,12 +333,9 @@ int main(int argc, char **argv)
 	int ret;
 	struct results_tree res;
 	struct filerec *file;
-	struct hash_tree scan_tree;
 
 	init_filerec();
 	init_results_tree(&res);
-
-	init_hash_tree(&scan_tree);
 
 	/* Parse options might change this so set a default here */
 #if GLIB_CHECK_VERSION(2,36,0)
@@ -389,9 +385,6 @@ int main(int argc, char **argv)
 		 */
 		ret = dbfile_get_config(&blocksize, NULL, NULL, NULL, NULL);
 		break;
-	case H_NONE:
-		ret = populate_tree_aim(&scan_tree);
-		break;
 	default:
 		abort_lineno();
 		break;
@@ -426,24 +419,20 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (use_hashfile == H_NONE) {
-		ret = find_all_dupes(&scan_tree, &res);
-	} else {
-		/* We will now reread the serialized file, and create a new
-		 * shiny tree with only duplicate hashes
-		 */
-		struct hash_tree dups_tree;
+	/* We will now reread the serialized file, and create a new
+	 * shiny tree with only duplicate hashes
+	 */
+	struct hash_tree dups_tree;
 
-		printf("Loading only duplicated hashes from hashfile.\n");
+	printf("Loading only duplicated hashes from hashfile.\n");
 
-		init_hash_tree(&dups_tree);
+	init_hash_tree(&dups_tree);
 
-		ret = dbfile_load_hashes(&dups_tree);
-		if (ret)
-			goto out;
+	ret = dbfile_load_hashes(&dups_tree);
+	if (ret)
+		goto out;
 
-		ret = find_all_dupes(&dups_tree, &res);
-	}
+	ret = find_all_dupes(&dups_tree, &res);
 
 	if (debug) {
 		print_dupes_table(&res);

--- a/file_scan.c
+++ b/file_scan.c
@@ -406,7 +406,7 @@ static void csum_whole_file_init(GMutex **mutex, void *location,
 	}
 }
 
-static void csum_whole_file_swap(struct filerec *file,
+static void csum_whole_file(struct filerec *file,
 				struct thread_params *params)
 {
 	uint64_t off = 0;
@@ -525,7 +525,7 @@ err_noclose:
 	return;
 }
 
-int populate_tree_swap()
+int populate_tree()
 {
 	int ret = 0;
 	GMutex mutex;
@@ -533,7 +533,7 @@ int populate_tree_swap()
 
 	struct thread_params params = { 0, 0, };
 
-	pool = setup_pool(&params, &mutex, csum_whole_file_swap);
+	pool = setup_pool(&params, &mutex, csum_whole_file);
 	if (!pool) {
 		ret = -1;
 		goto out;

--- a/file_scan.h
+++ b/file_scan.h
@@ -15,7 +15,7 @@ extern unsigned int io_threads;
  * Returns nonzero on fatal errors only
  */
 int add_file(const char *name, int dirfd);
-int populate_tree_swap();
+int populate_tree();
 
 /* For dbfile.c */
 struct block {

--- a/file_scan.h
+++ b/file_scan.h
@@ -15,7 +15,6 @@ extern unsigned int io_threads;
  * Returns nonzero on fatal errors only
  */
 int add_file(const char *name, int dirfd);
-int populate_tree_aim(struct hash_tree *tree);
 int populate_tree_swap();
 
 /* For dbfile.c */


### PR DESCRIPTION
Hello Mark,

The major stuff in these commits are:
- remove a unused index. Really reduce the db size (30% reduction, according to some tests)
- create index after all the data is inserted: this lower both cpu & memory consumption
- use in-memory database, so a single code path can be used. Plus, according to tests, it reduces by 70% the memory consumptions (really, from 1.6GB to 500MB!)