### PR TITLE
use O_RDONLY when deduping as root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.o
 duperemove
 btrfs-extent-same
+csum-test
+hashstats
+show-shared-extents
 *~

--- a/btrfs-extent-same.c
+++ b/btrfs-extent-same.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 	for (i = 0; i < same->dest_count; i++) {
 		destf = argv[4 + (i * 2)];
 
-		ret = open(destf, O_WRONLY);
+		ret = open(destf, geteuid() ? O_WRONLY : O_RDONLY);
 		if (ret < 0) {
 			ret = errno;
 			fprintf(stderr, "Could not open file %s: (%d) %s\n",

--- a/duperemove.8
+++ b/duperemove.8
@@ -60,8 +60,9 @@ De-dupe the results - only works on \fIbtrfs\fR.
 
 .TP
 \fB\-A\fR
-Opens files readonly when deduping. Primarily for use by privileged
-users on readonly snapshots.
+Opens files readonly when deduping; currently requires root privileges
+(and is enabled by default for root). Allows use on readonly snapshots
+or when the file might be open for exec.
 
 .TP
 \fB\-h\fR

--- a/duperemove.c
+++ b/duperemove.c
@@ -406,6 +406,8 @@ int main(int argc, char **argv)
 #else
 	io_threads = sysconf(_SC_NPROCESSORS_ONLN);
 #endif
+	if (!geteuid())
+		target_rw = 0;
 
 	if (parse_options(argc, argv)) {
 		usage(argv[0]);


### PR DESCRIPTION
As you just changed **btrfs-extent-same** the "wrong way" (but needed for unpatched kernels), here's a commit to make that change conditional based on whether we're running as root.

Doing the same to **duperemove** should fix the ETXTBSY race in 90% real life cases.

Once my kernel patch to allow ro operation goes in, we can prefix this by a kernel version check.
