### PR TITLE
add_file_db(): make arguments in file_scan.h and hashstats.c match.

### DIFF
--- a/hashstats.c
+++ b/hashstats.c
@@ -51,7 +51,7 @@ static sqlite3_stmt *find_blocks_stmt = NULL;
 
 /* dirty hack so we don't have to add file_scan.o to hashstats */
 int add_file_db(const char *filename, uint64_t inum, uint64_t subvolid,
-		uint64_t size, uint64_t mtime, int *delete)
+		uint64_t size, uint64_t mtime, unsigned int seq, int *delete)
 {
 	return 0;
 }


### PR DESCRIPTION
This fixes a -flto warning on gcc 6.1.1.

Warning was:

file_scan.h:28:5: warning: type of ‘add_file_db’ does not match original declaration [-Wlto-type-mismatch]
 int add_file_db(const char *filename, uint64_t inum, uint64_t subvolid,
     ^
hashstats.c:53:5: note: type mismatch in parameter 6
 int add_file_db(const char *filename, uint64_t inum, uint64_t subvolid,
     ^
hashstats.c:53:5: note: ‘add_file_db’ was previously declared here