### PR TITLE
fix some format string arguments pointed out by cppcheck:

### DIFF
--- a/dedupe.c
+++ b/dedupe.c
@@ -105,7 +105,7 @@ static void print_btrfs_same_info(struct dedupe_ctxt *ctxt)
 		info = &same->info[i];
 		req = same_idx_to_request(ctxt, i);
 		file = req->req_file;
-		dprintf(_PRE"info[%d]: name: \"%s\", fd: %llu, logical_offset: "
+		dprintf(_PRE"info[%d]: name: \"%s\", fd: %lli, logical_offset: "
 			"%llu, bytes_deduped: %llu, status: %d\n",
 			i, file ? file->filename : "(null)", (long long)info->fd,
 			(unsigned long long)info->logical_offset,

--- a/duperemove.c
+++ b/duperemove.c
@@ -50,10 +50,10 @@
 /* exported via debug.h */
 int verbose = 0, debug = 0;
 
-#define MIN_BLOCKSIZE	(4*1024)
+#define MIN_BLOCKSIZE	(4U*1024)
 /* max blocksize is somewhat arbitrary. */
-#define MAX_BLOCKSIZE	(1024*1024)
-#define DEFAULT_BLOCKSIZE	(128*1024)
+#define MAX_BLOCKSIZE	(1024U*1024)
+#define DEFAULT_BLOCKSIZE	(128U*1024)
 unsigned int blocksize = DEFAULT_BLOCKSIZE;
 
 int run_dedupe = 0;

--- a/filerec.c
+++ b/filerec.c
@@ -676,7 +676,7 @@ int filerec_count_shared(struct filerec *file, uint64_t start, uint64_t len,
 			if (fm_ext[i].fe_flags & FIEMAP_EXTENT_LAST)
 				last = 1;
 #ifndef FILEREC_TEST
-			dprintf("(fiemap) [%d] fe_logical: %llu, "
+			dprintf("(fiemap) [%u] fe_logical: %llu, "
 				"fe_length: %llu, fe_physical: %llu, "
 				"fe_flags: 0x%x\n",
 				i, (unsigned long long)fm_ext[i].fe_logical,
@@ -684,7 +684,7 @@ int filerec_count_shared(struct filerec *file, uint64_t start, uint64_t len,
 				(unsigned long long)fm_ext[i].fe_physical,
 				fm_ext[i].fe_flags);
 #else
-			dprintf("(fiemap) [%d] fe_logical: %llu, "
+			dprintf("(fiemap) [%u] fe_logical: %llu, "
 				"fe_length: %llu, fe_physical: %llu, "
 				"fe_flags: 0x%x %s\n",
 				i, (unsigned long long)fm_ext[i].fe_logical,

--- a/hashstats.c
+++ b/hashstats.c
@@ -252,7 +252,7 @@ static int major, minor;
 static void print_file_info(void)
 {
 	printf("Raw header info for \"%s\":\n", serialize_fname);
-	printf("  version: %u.%u\tblock_size: %u\n", major, minor,
+	printf("  version: %d.%d\tblock_size: %u\n", major, minor,
 	       disk_blocksize);
 	printf("  num_files: %"PRIu64"\tnum_hashes: %"PRIu64"\n",
 	       disk_files, disk_hashes);

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -393,7 +393,7 @@ run_dedupe:
 		 */
 		if (ctxt->num_queued) {
 			g_mutex_lock(&console_mutex);
-			printf("[%p] Dedupe %d extents (id: ", g_thread_self(),
+			printf("[%p] Dedupe %u extents (id: ", g_thread_self(),
 			       ctxt->num_queued);
 			debug_print_digest_short(stdout, dext->de_hash);
 			printf(") with target: (%s, %s), "


### PR DESCRIPTION
````
[dedupe.c:108]: (warning) %llu in format string (no. 3) requires 'unsigned long long' but the argument type is 'signed long long'.
[duperemove.c:394]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[duperemove.c:394]: (warning) %u in format string (no. 2) requires 'unsigned int' but the argument type is 'signed int'.
[filerec.c:679]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[filerec.c:687]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[hashstats.c:255]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'int'.
[hashstats.c:255]: (warning) %u in format string (no. 2) requires 'unsigned int' but the argument type is 'int'.
[run_dedupe.c:396]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
````