### PR TITLE
[RFC] Increase performance of duplicate digest search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VER=0.11.beta4
+VER=0.11.beta4-dev
 RELEASE=v$(VER)
 
 CC ?= gcc

--- a/dbfile.c
+++ b/dbfile.c
@@ -104,6 +104,12 @@ int create_indexes(sqlite3 *db)
 	if (ret)
 		goto out;
 
+#define	CREATE_DIGEST_REFCOUNTER_INDEX						\
+"create index if not exists idx_digest_refcounter on digest(refCounter);"
+	ret = sqlite3_exec(db, CREATE_DIGEST_REFCOUNTER_INDEX, NULL, NULL, NULL);
+	if (ret)
+		goto out;
+
 #define	CREATE_HASHES_INO_INDEX						\
 "create index if not exists idx_hashes_inosub on hashes(ino, subvol);"
 	ret = sqlite3_exec(db, CREATE_HASHES_INO_INDEX, NULL, NULL, NULL);


### PR DESCRIPTION
This patch increase the performance of duplicate searches by using an index table for digest.
If we deduplicate very large directorys (30 TB for example) the old implementation of dbfile_load_hashes will take many hours if you didn't have enough memory.

Details for a 3,9 TB directory, with 4723 objects:

old implementation of dbfile_load_hashes took 36593ms
new  implementation of dbfile_load_hashes took 11ms

Note:

If these changes are encouraged i will do some more work. Currently on the todo list:
1. Increase db version (DB_FILE_MAJOR to 3)
2. Add migration script for older db-files (DB_FILE_MAJOR == 2)
3. Delete orphaned entries in digest-table (refCount == 0)

Important:

I am not a c / c ++ developer. Please reviewe my changes also in regard to errors in the memory management.