### PR TITLE
Fix for: dbfile.c:(.text+0x1330): undefined reference to `makedev'

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -8,6 +8,7 @@
 #include <inttypes.h>
 #include <stddef.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "csum.h"
 #include "filerec.h"


### PR DESCRIPTION
glibc-2.24 does not include sysmacros.h from types.h, so include it manually.