### PR TITLE
Use atomic instead of sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ ifdef DEBUG
 endif
 override CFLAGS += -D_FILE_OFFSET_BITS=64 -DVERSTRING=\"$(RELEASE)\" \
 	$(hash_CFLAGS) $(glib_CFLAGS) $(sqlite_CFLAGS) -rdynamic $(DEBUG_FLAGS)
-LIBRARY_FLAGS += $(hash_LIBS) $(glib_LIBS) $(sqlite_LIBS) -lm
+LIBRARY_FLAGS += -Wl,--as-needed -latomic -lm
+LIBRARY_FLAGS += $(hash_LIBS) $(glib_LIBS) $(sqlite_LIBS)
 
 # make C=1 to enable sparse
 ifdef C

--- a/file_scan.c
+++ b/file_scan.c
@@ -660,7 +660,7 @@ static void csum_whole_file_init(GMutex **mutex, void *location,
 	unsigned long long cur_scan_files;
 	*mutex = g_dataset_get_data(location, "mutex");
 
-	cur_scan_files = __sync_add_and_fetch(&_cur_scan_files, 1);
+	cur_scan_files = __atomic_fetch_add(&_cur_scan_files, 1, __ATOMIC_SEQ_CST);
 
 	printf("[%0*llu/%llu] (%05.2f%%) csum: %s\n",
 	       leading_spaces, cur_scan_files, files_to_scan,

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -476,7 +476,7 @@ static int extent_dedupe_worker(struct dupe_extents *dext,
 				uint64_t *fiemap_bytes, uint64_t *kern_bytes)
 {
 	int ret;
-	unsigned long long passno = __sync_add_and_fetch(&curr_dedupe_pass, 1);
+	unsigned long long passno = __atomic_fetch_add(&curr_dedupe_pass, 1, __ATOMIC_SEQ_CST);
 
 	ret = dedupe_extent_list(dext, fiemap_bytes, kern_bytes, passno);
 	if (ret) {
@@ -659,7 +659,7 @@ static int block_dedupe_worker(struct block_dedupe_list *bdl,
 {
 	int ret;
 	struct results_tree res;
-	unsigned long long passno = __sync_add_and_fetch(&curr_dedupe_pass, 1);
+	unsigned long long passno =  __atomic_fetch_add(&curr_dedupe_pass, 1, __ATOMIC_SEQ_CST);
 
 	init_results_tree(&res);
 
@@ -804,8 +804,8 @@ static int __push_blocks(struct hash_tree *hashes,
 						goto out;
 					bdl = NULL;
 
-					__sync_add_and_fetch(
-						&total_dedupe_passes, 1);
+					 __atomic_fetch_add(
+						&total_dedupe_passes, 1, __ATOMIC_SEQ_CST);
 					break;
 				}
 			}


### PR DESCRIPTION
It was reported that it fails to compile for mips and mipsel architectures due to missing __sync* functions. Consider using __atomic instead

see:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851261