### PR TITLE
Restore file mtime for btrfs

### DIFF
--- a/dedupe.h
+++ b/dedupe.h
@@ -17,6 +17,8 @@
 #ifndef	__DEDUPE_H__
 #define	__DEDUPE_H__
 
+#include <time.h>
+
 #include "list.h"
 #include "btrfs-ioctl.h"
 


### PR DESCRIPTION
This patch saves and restores the file mtime across the deduplication process on btrfs.

Perhaps it could be written better:
  * Try to get nanosecond support for timestamp recovery
  * Add a check for kernels >= 4.9.0 to skip the recovery of the timestamp

Fixes: #165