### PR TITLE
Add --exclude option

### DIFF
--- a/duperemove.8
+++ b/duperemove.8
@@ -238,6 +238,11 @@ chance of collision. Xxhash may be faster but generates only 64 bit
 digests. Both hashes are fast enough that the default should work well
 for the overwhelming majority of users.
 
+.TP
+\fB\--exclude=PATTERN\fR
+You an exclude certain files and folders from the deduplication process.
+This might be benefical for skipping subvolume snapshot mounts, for instance.
+
 .SH "EXAMPLES"
 .SS "Simple Usage"
 Dedupe the files in directory /foo, recurse into all subdirectories. You only want to use this for small data sets.

--- a/duperemove.c
+++ b/duperemove.c
@@ -199,6 +199,17 @@ restart:
 	return err;
 }
 
+extern struct list_head exclude_list;
+
+static void add_exclude_pattern(const char *pattern)
+{
+	struct exclude_file *exclude = malloc(sizeof(*exclude));
+	if (exclude) {
+		exclude->pattern = strdup(pattern);
+		list_add_tail(&exclude->list, &exclude_list);
+	}
+}
+
 static void usage(const char *prog)
 {
 	char *s = NULL;
@@ -300,6 +311,7 @@ enum {
 	SKIP_ZEROES_OPTION,
 	FDUPES_OPTION,
 	DEDUPE_OPTS_OPTION,
+	EXCLUDE_OPTION,
 };
 
 static int add_files_from_stdin(int fdupes)
@@ -383,6 +395,7 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		{ "skip-zeroes", 0, NULL, SKIP_ZEROES_OPTION },
 		{ "fdupes", 0, NULL, FDUPES_OPTION },
 		{ "dedupe-options=", 1, NULL, DEDUPE_OPTS_OPTION },
+		{ "exclude", 1, NULL, EXCLUDE_OPTION },
 		{ NULL, 0, NULL, 0}
 	};
 
@@ -479,6 +492,9 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		case 'R':
 			rm_only_opt = 1;
 			add_rm_file(optarg);
+			break;
+		case EXCLUDE_OPTION:
+			add_exclude_pattern(optarg);
 			break;
 		case HELP_OPTION:
 			help_option = 1;

--- a/file_scan.c
+++ b/file_scan.c
@@ -33,6 +33,7 @@
 #include <inttypes.h>
 #include <linux/magic.h>
 #include <sys/statfs.h>
+#include <fnmatch.h>
 
 #include <glib.h>
 
@@ -66,6 +67,8 @@ struct thread_params {
 	int num_files;           /* Total number of files we hashed */
 	int num_hashes;          /* Total number of hashes we hashed */
 };
+
+LIST_HEAD(exclude_list);
 
 static void set_filerec_scan_flags(struct filerec *file)
 {
@@ -146,6 +149,18 @@ static int get_dirent_type(struct dirent *entry, int fd)
 	return DT_UNKNOWN;
 }
 
+static int is_excluded(const char *name) {
+	struct exclude_file *exclude, *tmp;
+	list_for_each_entry_safe(exclude, tmp, &exclude_list, list) {
+		if (fnmatch(exclude->pattern, name, FNM_PATHNAME) == 0) {
+			vprintf("Excluding: %s (matches %s)\n", name, exclude->pattern);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 static int walk_dir(const char *name)
 {
 	int ret = 0;
@@ -166,6 +181,9 @@ static int walk_dir(const char *name)
 		if (entry) {
 			if (strcmp(entry->d_name, ".") == 0
 			    || strcmp(entry->d_name, "..") == 0)
+				continue;
+
+			if (is_excluded(entry->d_name))
 				continue;
 
 			type = get_dirent_type(entry, dirfd(dirp));

--- a/file_scan.h
+++ b/file_scan.h
@@ -1,6 +1,8 @@
 #ifndef	__FILE_SCAN_H__
 #define	__FILE_SCAN_H__
 
+#include "list.h"
+
 /* from duperemove.c */
 extern int run_dedupe;
 extern int one_file_system;
@@ -38,6 +40,11 @@ struct block {
 	uint64_t	loff;
 	unsigned int	flags;
 	unsigned char	digest[DIGEST_LEN_MAX];
+};
+
+struct exclude_file {
+	char *pattern;
+	struct list_head list;
 };
 
 #endif	/* __FILE_SCAN_H__ */


### PR DESCRIPTION
It's possible I have a really strange setup. That said, I have a file server based on btrfs and create snapshots on an hourly basis. The snapshots are mounted read-only in a folder and provided via samba for easy recovery by clients.

When deduplicating, the content of the snapshots need not be considered, because the entire content of the snapshots is completely deduplicated already. Furthermore, with 20 snapshots of 300k+ files, the deduplication process becomes an unnecessarily difficult and time-consuming chore.

So, I added the ability to exclude certain files and folders from the deduplication process with a --exclude command-line option. So then I can do

    duperemove -drh --exclude=.snapshots --hashfile=dupes.db /path/to/shares

And then only the files I expect to be changing are considered for deduplication.

The patch uses a wildcard patching mechanism (GNU `fnmatch`), and only matches the basename of the files and folders. That's sufficient for me, but might need to be polished for the masses.