### PR TITLE
Add a Dockerfile for easier consumption of duperemove

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine as builder
+
+RUN apk add \
+    build-base \
+    pkgconfig \
+    sqlite-dev \
+    glib-dev \
+    linux-headers
+
+ADD . /app
+
+WORKDIR app
+
+RUN make
+
+# We don't need all the packages from the build container to keep the image small
+FROM alpine
+
+RUN apk add sqlite-dev glib-dev
+
+COPY --from=builder /app/duperemove /usr/bin/duperemove
+
+ENTRYPOINT ["/usr/bin/duperemove"]


### PR DESCRIPTION
This adds a Dockerfile to be able to use duperemove on platforms where it is
not natively available (e.g. Synology NAS systems).

Having a Docker image makes it easier to use duperemove. The user just needs
to bind-mount the directory he wants to dedupe into the container:

```
docker run -v /folder/to/dedupe:/to/dedupe duperemove -rdhv /to/dedupe
```

Signed-off-by: Jannick Fahlbusch <git@jf-projects.de>