### PR TITLE
Fix out-of-bounds access to fm_extents when reading next part of fiemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.o
 duperemove
 btrfs-extent-same
+csum-test
+hashstats
+show-shared-extents
 *~

--- a/filerec.c
+++ b/filerec.c
@@ -552,7 +552,7 @@ int fiemap_iter_next_extent(struct fiemap_ctxt *ctxt, struct filerec *file,
 
 	if (idx == -1 || idx >= fiemap->fm_mapped_extents) {
 		if (idx != -1) {
-			extent = &fiemap->fm_extents[idx];
+			extent = &fiemap->fm_extents[idx - 1];
 			fiestart = extent->fe_logical + extent->fe_length;
 		}
 		ret = do_fiemap(fiemap, file, fiestart);


### PR DESCRIPTION
This should fix #211 .

I am not familiar with kernel stuff. I referred to https://github.com/ColinIanKing/fiemap and thought that previous code reads the address of the next part fiemap from the wrong place.

I also update the `.gitignore` to include more compiled binaries.