### PR TITLE
Don't link with libatomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ endif
 
 override CFLAGS += -D_FILE_OFFSET_BITS=64 -DVERSTRING=\"$(RELEASE)\" \
 	$(hash_CFLAGS) $(glib_CFLAGS) $(sqlite_CFLAGS) -rdynamic $(DEBUG_FLAGS)
-LIBRARY_FLAGS += -Wl,--as-needed -latomic -lm
 LIBRARY_FLAGS += $(hash_LIBS) $(glib_LIBS) $(sqlite_LIBS)
 
 # make C=1 to enable sparse


### PR DESCRIPTION
__atomic* functions are built-in in gcc so there shouldn't be a need to
link against libatomic explicitly.