### PR TITLE
Fix remove_file_hashes_prep retval in case of success

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -992,7 +992,7 @@ static int remove_file_hashes_prep(sqlite3 *db, struct dbfile_config *cfg,
 			perror_sqlite(ret, "preparing hash insert statement");
 		return ret;
 	}
-	return EINVAL;
+	return 0;
 }
 
 static int dbfile_remove_file_hashes(sqlite3 *db, struct dbfile_config *cfg,


### PR DESCRIPTION
For some reason this function was returning EINVAL in case of success.
Instead return 0.