### PR TITLE
Handle overflow in csum_extent

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -738,7 +738,7 @@ static int csum_extent(struct csum_ctxt *data, uint64_t extent_off,
 	finish_running_checksum(csum, data->digest);
 
 	*ret_total_bytes_read = total_bytes_read;
-	ret = total_bytes_read;
+	ret = (total_bytes_read > 0) ? 1 : 0; // handle overflow
 	return ret;
 }
 

--- a/file_scan.c
+++ b/file_scan.c
@@ -738,7 +738,7 @@ static int csum_extent(struct csum_ctxt *data, uint64_t extent_off,
 	finish_running_checksum(csum, data->digest);
 
 	*ret_total_bytes_read = total_bytes_read;
-	ret = (total_bytes_read > 0) ? 1 : 0; // handle overflow
+    ret = (total_bytes_read == 0) ? 0 : 1; // handle overflow
 	return ret;
 }
 

--- a/file_scan.c
+++ b/file_scan.c
@@ -738,7 +738,7 @@ static int csum_extent(struct csum_ctxt *data, uint64_t extent_off,
 	finish_running_checksum(csum, data->digest);
 
 	*ret_total_bytes_read = total_bytes_read;
-    ret = (total_bytes_read == 0) ? 0 : 1; // handle overflow
+	ret = (total_bytes_read == 0) ? 0 : 1; // handle overflow
 	return ret;
 }
 


### PR DESCRIPTION
I came across the same issue as in #241 -- turns out `total_bytes_read` (unsigned int) was written into `ret` (int) and overflowed on large files. It would seem in the two places that call `csum_extent`, they only care if value is negative (error), zero (EOF), or positive (continue) and not "how positive" it is -- so I've just added a simple check to fix the return code and send back a 1 instead of `total_bytes_read`.