### PR TITLE
Handle colliding extents

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -1514,10 +1514,10 @@ int dbfile_load_extent_hashes(struct results_tree *res)
 	 * result of only one extent.
 	 */
 #define GET_DUPLICATE_EXTENTS					      \
-	"SELECT extents.digest, ino, subvol, loff, len, poff, flags FROM extents " \
-	"JOIN (SELECT digest FROM extents GROUP BY digest " \
-				"HAVING count(*) > 1) AS duplicate_extents " \
-	"on extents.digest = duplicate_extents.digest;"
+	"SELECT extents.digest, ino, subvol, loff, extents.len, poff, flags FROM extents " \
+	"JOIN (SELECT digest,len FROM extents GROUP BY digest,len HAVING count(*) > 1) " \
+	"AS duplicate_extents on extents.digest = duplicate_extents.digest AND " \
+	"extents.len = duplicate_extents.len;"
 
 	ret = sqlite3_prepare_v2(db, GET_DUPLICATE_EXTENTS, -1, &stmt, NULL);
 	if (ret) {


### PR DESCRIPTION
Currently if we have 2 extents which have the same hash but different
size it will trigger an abort in dedupe_extent_list. The reason is that
the query used to get dupe extents in dbfile_load_extent_hashes ignores
the len of the extent and instead only matches on digest. This would
result in creating 2 distinct struct dupe_extents with only a single
entry, this in turn results in triggering an assertion in
dedupe_extent_list.

Fix this by changing to the SQL statement responsible for loading dupes
to consider the 'len' column as well.