### PR TITLE
Revert "Don't link with libatomic"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ endif
 
 override CFLAGS += -D_FILE_OFFSET_BITS=64 -DVERSTRING=\"$(RELEASE)\" \
 	$(hash_CFLAGS) $(glib_CFLAGS) $(sqlite_CFLAGS) -rdynamic $(DEBUG_FLAGS)
+LIBRARY_FLAGS += -Wl,--as-needed -latomic -lm
 LIBRARY_FLAGS += $(hash_LIBS) $(glib_LIBS) $(sqlite_LIBS)
 
 # make C=1 to enable sparse


### PR DESCRIPTION
GCC has the _headers_ for __atomic built-in, but it still needs library
support on many architectures.  On Debian, this broke armel mipsel m68k
powerpc sh4.

--as-needed does precisely what we want: links the library only if it's
actually required, with no bloat added when not.

This reverts commit 06160235310a98f41c3f0e46e8f42e57dba11bc3.