### PR TITLE
Create hash database file with 600 permission

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -8,6 +8,7 @@
 #include <inttypes.h>
 #include <stddef.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/syscall.h>
 
@@ -224,6 +225,15 @@ reopen:
 		dbfile_config_defaults(cfg);
 		cfg->major = requested_version;
 		cfg->minor = requested_version == DB_FILE_MAJOR ? DB_FILE_MINOR : 0;
+		if (!inmem) {
+			ret = chmod(filename, S_IRUSR|S_IWUSR);
+			if (ret) {
+				perror("setting db file permissions");
+				sqlite3_close(db);
+				return ret;
+			}
+
+		}
 	} else {
 		/* Get only version numbers initially */
 		ret = __dbfile_get_config(db, NULL, NULL, NULL, NULL, NULL,


### PR DESCRIPTION
The argument was made that since the hashfile contains paths and
content hashesh for files and directories that are otherwise protected
by the filesystem permissions. Fix this by explicitly setting the
permissions for a newly created database file to 600.

close #262