### PR TITLE
duperemove: increase open file limit from default to maximum available

### DIFF
--- a/duperemove.c
+++ b/duperemove.c
@@ -727,6 +727,14 @@ int main(int argc, char **argv)
 		return (version_only || help_option) ? 0 : EINVAL;
 	}
 
+	/* Allow larger than unusal amount of open files. On linux
+	 * this should bw increase form 1K to 512K open files
+	 * simultaneously.
+	 *
+	 * On multicore SSD machines it's not hard to get to 1K open
+	 * files.
+	 */
+	increase_limits();
 	/*
 	 * Don't run detection if the user has supplied our cpu counts
 	 * already.

--- a/util.h
+++ b/util.h
@@ -53,4 +53,7 @@ int num_digits(unsigned long long num);
 
 void get_num_cpus(unsigned int *nr_phys, unsigned int *nr_log);
 
+/* Bump up maximum open file limit. */
+int increase_limits(void);
+
 #endif	/* __UTIL_H__ */


### PR DESCRIPTION
On 32-CPU machine with SSD I occasionally get -EMFILE errors when deduping as:
    # duperemove -dr --hashfile=dupes.db /

My guess is that we exhausl relatively small 1K default RLIMIT_NOFILE.
The change cranks up the limit from 1K to 512K on x86_64 linux.