### PR TITLE
Add zsh completion for main duperemove command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CFLAGS ?= -Wall -ggdb
 PKG_CONFIG ?= pkg-config
 
 MANPAGES=duperemove.8 btrfs-extent-same.8 hashstats.8 show-shared-extents.8
+ZSH_COMPLETION=completion/zsh/_duperemove
 
 HEADERS=csum.h hash-tree.h results-tree.h kernel.h list.h rbtree.h dedupe.h \
 	ioctl.h filerec.h btrfs-util.h debug.h util.h \
@@ -108,7 +109,7 @@ tarball: clean $(DIST_SOURCES)
 btrfs-extent-same: btrfs-extent-same.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o btrfs-extent-same btrfs-extent-same.c
 
-install: $(install_progs) $(MANPAGES)
+install: $(install_progs) $(MANPAGES) $(ZSH_COMPLETION)
 	mkdir -p -m 0755 $(DESTDIR)$(BINDIR)
 	for prog in $(install_progs); do \
 		install -m 0755 $$prog $(DESTDIR)$(BINDIR); \
@@ -117,6 +118,10 @@ install: $(install_progs) $(MANPAGES)
 	for man in $(MANPAGES); do \
 		install -m 0644 $$man $(DESTDIR)$(MANDIR)/man8; \
 	done
+	mkdir -p -m 0755 $(DESTDIR)$(SHAREDIR)/zsh/site-functions
+	for completion in $(ZSH_COMPLETION); do \
+		install -m 0644 $$completion $(DESTDIR)$(SHAREDIR)/zsh/site-functions; \
+	done
 
 uninstall:
 	for prog in $(install_progs); do \
@@ -124,6 +129,9 @@ uninstall:
 	done
 	for man in $(MANPAGES); do \
 		rm -f $(DESTDIR)$(MANDIR)/man8/$$man; \
+	done
+	for completion in $(ZSH_COMPLETION); do \
+		rm -f $(DESTDIR)$(SHAREDIR)/zsh/site-functions/$${completion##*/}; \
 	done
 
 csum-test: $(csum_test_obj) csum-test.c

--- a/completion/zsh/_duperemove
+++ b/completion/zsh/_duperemove
@@ -1,0 +1,44 @@
+#compdef duperemove
+
+_duperemove_options()
+{
+	declare -a dedupe_options
+	dedupe_options=(
+		'(only_whole_files)noonly_whole_files[work on extents/blocks (default)]'
+		'(noonly_whole_files)only_whole_files[only work on whole files]'
+		'(partial)nopartial[compare only whole extents]'
+		'(nopartial)partial[compare portions of extents (default)]'
+		'(same)nosame[do not allow dedupe of extents within the same file (default)]'
+		'(nosame)same[allow dedupe of extents within the same file (default)]'
+	)
+	_values -s , option $dedupe_options
+}
+
+_duperemove() {
+	declare -a args
+	args=(
+		'--hashfile=[store hashes in this file]:file:_files'
+		'-d[de-dupe the results (must run on a supported fs)]'
+		'(-B --batchsize)'{-B,--batchsize}'[Run deduplication in batches]:number of files: '
+		'-h[print numbers in human-readable format]'
+		'-r[enable recursive dir traversal]'
+		'-v[print extra information (verbose)]'
+		'(-)--help[print help text]'
+		'(-)--version[display version information and exit]'
+		'-L[print all files in hashfile and exit]'
+		'-R[remove files from db and exit]:*:file:_files'
+		'--fdupes[run in fdupes mode]'
+		'--skip-zeros[read data blocks and skip any zeroed blocks]'
+		'-b[use the specified block size]:block size: '
+		'--io-threads=[use N threads for IO]:number of thread: '
+		'--cpu-threads=[use N threads for CPU bound tasks]:number of thread: '
+		'--dedupe-options=[comma separated list of options]:options:_duperemove_options'
+		'--read-hashes=[testing option: read hashes from hashfile (use --hashfile instead)]:file:_files'
+		'--write-hashes=[testing option: write hashes to hashfile (use --hashfile instead)]:file:_files'
+		'--debug[print debug messages]'
+		'--exclude=[Exclude files]:file:_files'
+		'*:file:_files'
+	)
+
+	_arguments $args
+}


### PR DESCRIPTION
This PR adds zsh compltion for the main duperemove command. I did not create zsh completion for the other commands as after reading the man pages they appeared to be more of debugging commands and not worth the effort.

Unfortunately I don't have the skill to write an equivalent bash completion file.