### PR TITLE
Patch hashfile pragmas for ideal sqlite3 behaviour

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -185,7 +185,7 @@ static int dbfile_set_modes(sqlite3 *db)
 	}
 
 //	Grow cache size see issue #283
-	ret = sqlite3_exec(db, "PRAGMA cach_size = -20000", NULL, NULL, NULL);
+	ret = sqlite3_exec(db, "PRAGMA cache_size = -20000", NULL, NULL, NULL);
 	if (ret) {
 		perror_sqlite(ret, "configuring database (cache_size)");
 		return ret;


### PR DESCRIPTION
- 10x sqlite cache.
- synchronous = 1 , just syncing normally much safer than not at all, perfectly fine as long you don't need to sync too often.
- WAL mode is just better in a number of ways.
- Not syncing WAL aggressively since we turned synchronous back on.