### PR TITLE
Use ?= to set VERSION and IS_RELEASE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
-VERSION=$(shell git describe --abbrev=4 --dirty --always --tags;)
-ifeq ($(shell git rev-list $(shell git describe --abbrev=0 --tags --exclude '*dev';)..HEAD --count;), 0)
-	IS_RELEASE=1
-else
-	IS_RELEASE=0
-endif
+VERSION ?= $(shell git describe --abbrev=4 --dirty --always --tags;)
+IS_RELEASE ?= $(if $(filter $(shell git rev-list $(shell git describe --abbrev=0 --tags --exclude '*dev';)..HEAD --count;),0),1,0)
 
 CC ?= gcc
 CFLAGS ?= -Wall -ggdb


### PR DESCRIPTION
0ed39333d222c3b171dbdf1ca476ad65ca201d65 broke building from release tarballs. This fixes it as long as you pass VERSION and IS_RELEASE yourself.