### PR TITLE
file_scan.c: don't use calloc() in csum_whole_file()

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -887,7 +887,7 @@ static void csum_whole_file(struct filerec *file,
 	struct block_csum *block_hashes = NULL;
 
 	memset(&csum_ctxt, 0, sizeof(csum_ctxt));
-	csum_ctxt.buf = calloc(1, READ_BUF_LEN);
+	csum_ctxt.buf = malloc(READ_BUF_LEN);
 	assert(csum_ctxt.buf != NULL);
 	csum_ctxt.file = file;
 


### PR DESCRIPTION
The setup: create 100K files 1024 bytes each. This is 100MB input:

    echo "Creating directory structure, will take a minute"
    mkdir dd
    for d in `seq 1 100`; do
        mkdir dd/$d
        for f in `seq 1 1000`; do
            printf "%*s" 1024 "$f" > dd/$d/$f
        done
    done
    sync

Before the change this input took 40 seconds to process:

    $ time ./duperemove -q -rd dd/
    ...
    real    0m39,835s
    user    1m54,903s
    sys     0m8,922s

After the change we get 2x speedup in performance:

    $ time ./duperemove -q -rd dd/
    ...
    real    0m14,616s
    user    0m11,942s
    sys     0m2,580s

The main overhead was in a single `calloc(8MB)` call against each small file. The change should decrease this setup overhead when running against small files.