### PR TITLE
filerec_count_shared(): fix sharing accounting

### DIFF
--- a/filerec.c
+++ b/filerec.c
@@ -610,7 +610,7 @@ int filerec_count_shared(struct filerec *file, uint64_t loff, uint32_t len,
 			    && flags & FIEMAP_EXTENT_SHARED) {
 				if (extent_loff < loff)
 					extent_loff = loff;
-				if (extent_end < end)
+				if (end < extent_end)
 					extent_end = end;
 				*shared += extent_end - extent_loff + 1;
 			}


### PR DESCRIPTION
Before the change `filerec_count_shared()` incorrectly accounted for extent end compared to file end:

    $ ls -lh /nix/var/nix/db/db.sqlite
    -rw-r--r-- 1 root root 1.4G Nov  9 22:21 /nix/var/nix/db/db.sqlite

Before the change due to incorrect tail handling sharing reported size larger than the file itself:

    $ ./show-shared-extents /nix/var/nix/db/db.sqlite
    /nix/var/nix/db/db.sqlite: 27065321263104 shared bytes

After the change sharing reports a reasonable value:

    $ ./show-shared-extents /nix/var/nix/db/db.sqlite
    /nix/var/nix/db/db.sqlite: 1169276928 shared bytes

Note: before the change sharing reported a few orders of magnitude savings larger than initial file size. After the change the value is more reasonable.