### PR TITLE
file_scan: satisfy clang CFI

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -191,6 +191,11 @@ static void free_scan_ctxt(struct scan_ctxt *ctxt)
 		finish_running_checksum(ctxt->extent_csum, NULL);
 }
 
+static void cleanup_dbhandle(void *db)
+{
+	dbfile_close_handle(db);
+}
+
 static struct dbhandle *get_db()
 {
 	struct dbhandle *db;
@@ -199,7 +204,7 @@ static struct dbhandle *get_db()
 	db = dbfile_open_handle(options.hashfile);
 	dbfile_unlock();
 	if (db)
-		register_cleanup(&scan_pool, (void*)&dbfile_close_handle, db);
+		register_cleanup(&scan_pool, (void*)&cleanup_dbhandle, db);
 	return db;
 }
 


### PR DESCRIPTION
`dbfile_close_handle` takes `struct dbhandle*`; CFI doesn't like it being called as a function taking `void*`. This can be worked around by passing `-fsanitize-cfi-icall-generalize-pointers`, but it seemed easy enough to just make the code compliant.