### PR TITLE
util.c: make debug helper `-Wformat-security`-clean

### DIFF
--- a/util.c
+++ b/util.c
@@ -337,5 +337,5 @@ void debug_print_uuid(FILE *stream, uuid_t uuid)
 {
 	char buf[37];
 	uuid_unparse(uuid, buf);
-	fprintf(stream, buf);
+	fputs(buf, stream);
 }


### PR DESCRIPTION
Without the change `gcc-14` fails the build with `-Werror=format-security` as:

    util.c:340:25: error: format not a string literal and no format arguments [-Werror=format-security]
      340 |         fprintf(stream, buf);
          |                         ^~~

It's a harmless warning as `UUID` has a well-defined set of characters. But `fputs()` expresses intent more directly to print the string as is.