### PR TITLE
Fix partial deduplication

### DIFF
--- a/dbfile.h
+++ b/dbfile.h
@@ -18,7 +18,7 @@ struct results_tree;
 struct dbfile_config;
 
 #define DB_FILE_MAJOR	4
-#define DB_FILE_MINOR	0
+#define DB_FILE_MINOR	1
 
 struct stmts {
 	sqlite3_stmt *insert_block;

--- a/hashstats.c
+++ b/hashstats.c
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
 		print_by_size(db);
 
 	if (print_file_list) {
-		printf("Showing %"PRIu64" files.\nInode\tSubvol ID\tBlocks Stored\tSize\tFilename\n",
+		printf("Showing %"PRIu64" files.\nInode\tSubvol ID\tSize\tFilename\n",
 			dbfile_stats.num_files);
 		dbfile_list_files(db, print_files_cb);
 	}


### PR DESCRIPTION
Avoid temporary tables due to missing indexes.
Added missing indexes.
Made index names consistent.
Removed unused blocks column.

Fixes #347

Tested with (btrfs/compression):
```
data: 584G
hashfile: 2,7G
num_files: 4825823	num_block_hashes: 5293475	num_extent_hashes: 2671643
```