### PR TITLE
btrfs-extent-same.8: Fix manpage reference

### DIFF
--- a/btrfs-extent-same.8
+++ b/btrfs-extent-same.8
@@ -33,6 +33,6 @@
 .IP \[bu] 2
 \f[V]btrfs(8)\f[R]
 .IP \[bu] 2
-\f[V]ioctl_fideduprange(2)\f[R]
+\f[V]ioctl_fideduperange(2)\f[R]
 .IP \[bu] 2
 \f[V]xfs_io(8)\f[R]


### PR DESCRIPTION
`ioctl_fideduprange` doesn't look like a real manpage.