### PR TITLE
dedupe: Skip extents with insufficient duplicates

### DIFF
--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -561,10 +561,15 @@ static int push_extents(struct results_tree *res)
 		 * around the rbtree code here so rb_erase doesn't
 		 * change the tree underneath us.
 		 */
-
 		g_mutex_lock(&mutex);
 		node = rb_next(node);
 		g_mutex_unlock(&mutex);
+
+		if (dext->de_num_dupes < 2) {
+			qprintf("Skipping extent - insufficient duplicates (%u)\n",
+				   dext->de_num_dupes);
+			continue;
+		}
 
 		g_thread_pool_push(dedupe_pool, dext, &err);
 		if (err) {


### PR DESCRIPTION
De-duping my Unity Avatar's library on bcachefs always resulted in aborts of this type:

```
❯ gdb --args duperemove -dr --io-threads=1 --hashfile=".duperemove.hash" *
Gathering file list...
[New Thread 0x7ffff41ff6c0 (LWP 221298)]

process_extents: unable to get extent
file /mnt/bcachefs/windowsvm-share/3DModels/WickerBapper-v2.2/Library/ArtifactDB-lock changed
process_extents: unable to get extent
file /mnt/bcachefs/windowsvm-share/3DModels/WickerBapper-v2.2/Library/SourceAssetDB-lock changed
process_extents: unable to get extent
file /mnt/bcachefs/windowsvm-share/3DModels/WickerBapper-v2.2/Library/SourceAssetDB changed
process_extents: unable to get extent
file /mnt/bcachefs/windowsvm-share/3DModels/WickerBapper-v2.2/Library/ArtifactDB changed
    Files scanned: 4/4 (100.00%)
    Bytes scanned: 25182208/25182208 (100.00%)
    File listing: completed
[Thread 0x7ffff39fe6c0 (LWP 221299) exited]
Hashfile ".duperemove.hash" written
Loading only identical files from hashfile.
Simple read and compare of file data found 5 instances of files that might benefit from deduplication.
Showing 6 identical files of length 2488 with id 196d52ba
Start		Filename
0	"/mnt/bcachefs/windowsvm-share/3DModels/NovaBeastV3.3/Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Resources/thryEditor_link.png.meta"
...
[0x507000008ec0] Skipping - extents are already deduped.
ERROR: run_dedupe.c:287
[stack trace follows]
/usr/lib/libasan.so.8(___interceptor_backtrace+0xa4) [0x7ffff794ca14]
/usr/bin/duperemove(+0x41b54) [0x555555595b54]
/usr/bin/duperemove(+0x3dcda) [0x555555591cda]
/usr/bin/duperemove(+0x3f140) [0x555555593140]
/usr/bin/duperemove(+0x3f4c4) [0x5555555934c4]
/usr/lib/libglib-2.0.so.0(+0x95ca3) [0x7ffff77e9ca3]
/usr/lib/libglib-2.0.so.0(+0x92be6) [0x7ffff77e6be6]
/usr/lib/libasan.so.8(+0x5d10a) [0x7ffff790110a]
/usr/lib/libc.so.6(+0x942ce) [0x7ffff73c32ce]
/usr/lib/libc.so.6(+0x11929c) [0x7ffff744829c]
```

I had to add a safety check in push_extents() to prevent those crashes from randomly happening.

This prevents assertion failures in dedupe_extent_list() when the duplicate count drops below 2 between the initial duplicate detection and worker thread processing.  Even when reducing I/O thread count I did encounter this on my setup.  Maybe because I have many CPU cores? (Ryzen 9 7950X3D / 32 threads).

I'm not sure I understand correctly why the problem happened in the first place so I'll let that to you to review.

Note: Many of the lines above say the file has changed, but those are archives, nothing should change in those folders.