### PR TITLE
Gnu11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION ?= $(shell git describe --abbrev=4 --dirty --always --tags;)
 IS_RELEASE ?= $(if $(filter $(shell git rev-list $(shell git describe --abbrev=0 --tags --exclude '*dev';)..HEAD --count;),0),1,0)
 
 CC ?= gcc
-CFLAGS ?= -Wall -ggdb --std=c23 -MMD
+CFLAGS ?= -Wall -ggdb -std=gnu11 -Werror=strict-prototypes -MMD
 PKG_CONFIG ?= pkg-config
 
 MANPAGES=duperemove.8 btrfs-extent-same.8 hashstats.8 show-shared-extents.8

--- a/dbfile.h
+++ b/dbfile.h
@@ -77,8 +77,8 @@ void dbfile_close_handle(struct dbhandle *db);
  */
 struct dbhandle *dbfile_open_handle_thread(char *filename, struct threads_pool *pool);
 
-void dbfile_lock();
-void dbfile_unlock();
+void dbfile_lock(void);
+void dbfile_unlock(void);
 
 struct dbfile_config {
 	unsigned int	blocksize;

--- a/duperemove.c
+++ b/duperemove.c
@@ -130,7 +130,7 @@ static int rm_db_files(int numfiles, char **files)
 	return 0;
 }
 
-static void print_version()
+static void print_version(void)
 {
 	char *s = NULL;
 #ifdef	DEBUG_BUILD
@@ -206,7 +206,7 @@ enum {
 	BATCH_SIZE_OPTION,
 };
 
-static int process_fdupes()
+static int process_fdupes(void)
 {
 	int ret = 0;
 	_cleanup_(freep) char *path = NULL;
@@ -285,7 +285,7 @@ static int scan_files_from_cmdline(int numfiles, char **files, struct dbhandle *
 	return 0;
 }
 
-static void help()
+static void help(void)
 {
 	execlp("man", "man", "8", "duperemove", NULL);
 }

--- a/file_scan.h
+++ b/file_scan.h
@@ -47,8 +47,8 @@ struct file_to_scan {
 
 int add_exclude_pattern(const char *pattern);
 
-void filescan_init();
-void filescan_free();
+void filescan_init(void);
+void filescan_free(void);
 
 void add_file_fdupes(char *path);
 #endif	/* __FILE_SCAN_H__ */

--- a/hashstats.c
+++ b/hashstats.c
@@ -138,7 +138,7 @@ static void print_file_info(char *fname, struct dbfile_config *cfg,
 	       stats->num_files, stats->num_b_hashes, stats->num_e_hashes);
 }
 
-static void version()
+static void version(void)
 {
 	printf("hashstats %s\n", VERSTRING);
 }

--- a/list.h
+++ b/list.h
@@ -31,6 +31,7 @@ struct hlist_node {
 
 #define LIST_HEAD_INIT(name) { &(name), &(name) }
 
+#undef LIST_HEAD // <bsd/sys/queue.h>
 #define LIST_HEAD(name) \
 	struct list_head name = LIST_HEAD_INIT(name)
 

--- a/progress.c
+++ b/progress.c
@@ -176,7 +176,7 @@ static void *print_progress(void)
 	return NULL;
 }
 
-static void *pscan_progress_thread(void *)
+static void *pscan_progress_thread(void * p)
 {
 	struct winsize w;
 	do {
@@ -215,7 +215,7 @@ struct pscan_thread *pscan_register_thread(pid_t tid)
 	return tprogress;
 }
 
-void pscan_run()
+void pscan_run(void)
 {
 	tty = isatty(STDOUT_FILENO);
 
@@ -230,7 +230,7 @@ void pscan_run()
 	printer = g_thread_new("progress_printer", pscan_progress_thread, NULL);
 }
 
-void pscan_join()
+void pscan_join(void)
 {
 	g_thread_join(printer);
 
@@ -277,7 +277,7 @@ void pscan_reset_thread(struct pscan_thread **progress)
 	(*progress)->file_path[0] = '\0';
 }
 
-bool is_progress_printer_running()
+bool is_progress_printer_running(void)
 {
 	return printer ? true : false;
 }
@@ -312,7 +312,7 @@ void pscan_printf(char *fmt, ...)
 	g_mutex_unlock(&pscan.mutex);
 }
 
-static void *psearch_progress_thread(void *)
+static void *psearch_progress_thread(void * p)
 {
 	static int last_pos = -1;
 

--- a/progress.h
+++ b/progress.h
@@ -39,7 +39,7 @@ struct pscan_global {
 	struct pscan_thread	**threads;
 };
 
-void pscan_finish_listing();
+void pscan_finish_listing(void);
 
 /* Used to increment the global todo list */
 void pscan_set_progress(uint64_t added_files, uint64_t added_bytes);
@@ -53,13 +53,13 @@ struct pscan_thread *pscan_register_thread(pid_t tid);
  * - the listing is completed - pscan_finish_listing() has been called
  * - the sum of all threads progresses equals to the global totals
  */
-void pscan_run();
+void pscan_run(void);
 
 /*
  * Wait for the progress thread to finish
  * Also cleanup per-thread progresses and print the global totals
  */
-void pscan_join();
+void pscan_join(void);
 
 /*
  * Reset file tracking data
@@ -69,7 +69,7 @@ void pscan_join();
  */
 void pscan_reset_thread(struct pscan_thread **progress);
 
-bool is_progress_printer_running();
+bool is_progress_printer_running(void);
 
 /*
  * The progress thread overwrites its area.
@@ -87,7 +87,7 @@ void psearch_run(uint64_t num_filerecs);
 /*
  * Wait for the progress thread to finish
  */
-void psearch_join();
+void psearch_join(void);
 
 /*
  * extent search: update the number of processed filerecs


### PR DESCRIPTION
Make C11 compatible
    
Many distros still don't have full C23 support, and duperemove doesn't use any C23 library features, so just make the codebase `-Wstrict-prototypes` compliant, which works in C11 and C23 mode.

Bug: https://bugs.gentoo.org/949339