### PR TITLE
dedupe.c: fix infinite looping on NoCOW files

### DIFF
--- a/dedupe.c
+++ b/dedupe.c
@@ -306,7 +306,6 @@ static void process_dedupes(struct dedupe_ctxt *ctxt,
 		 * get -EINVAL on all the fds. Short circuit this then
 		 * by moving everything off the queued list.
 		 */
-		fs_blocksize = get_fs_blocksize(ctxt->ioctl_file->fd);
 		list_splice_init(&ctxt->queued, &ctxt->completed);
 	}
 }
@@ -328,6 +327,7 @@ retry:
 			print_btrfs_same_info(ctxt);
 
 		if (ctxt->same->info[0].status == -EINVAL && !fs_blocksize) {
+			fs_blocksize = get_fs_blocksize(ctxt->ioctl_file->fd);
 			set_aligned_same_length(ctxt, ctxt->same);
 			goto retry;
 		}


### PR DESCRIPTION
Without the change dedupe hangs on NoCOW files as:

    $ dd if=/dev/urandom bs=8M count=1 > a
    $ touch b
    $ chattr +C b
    $ cat a >> b

    $ lsattr a b
    ---------------------- a
    ---------------C------ b

    $ ./duperemove -d -q --batchsize=0 --dedupe-options=partial,same a b
    Simple read and compare of file data found 1 instances of files that might benefit from deduplication.
    <hung up>

The regression was introduced by c714a4d3b713f26b8936e2fc7583d30666d73fa0 "dedupe: do not grab block transfer for each file" where `fs_blocksize` initialization was moved from `EINVAL` case to somewhere where it never gets executed. THat made `INVAL` case loop indefinitely.

THe change moves `fs_blocksize` initialization back to `EINVAL` handling case.

Closes: https://github.com/markfasheh/duperemove/issues/375