### PR TITLE
fiemap: use hint index in get_extent to avoid O(n*m) extent lookups

### DIFF
--- a/fiemap.c
+++ b/fiemap.c
@@ -48,8 +48,14 @@ struct fiemap_extent *get_extent(struct fiemap *fiemap, size_t loff,
 {
 	struct fiemap_extent *extent;
 	size_t ext_end_off;
+	unsigned int start = 0;
 
-	for (unsigned int i = 0; i < fiemap->fm_mapped_extents; i++) {
+	/* Use hint if it doesn't point past the target offset */
+	if (index && *index < fiemap->fm_mapped_extents &&
+	    fiemap->fm_extents[*index].fe_logical <= loff)
+		start = *index;
+
+	for (unsigned int i = start; i < fiemap->fm_mapped_extents; i++) {
 		extent = &fiemap->fm_extents[i];
 		ext_end_off = extent->fe_logical + extent->fe_length - 1;
 		if (ext_end_off < loff)

--- a/fiemap.h
+++ b/fiemap.h
@@ -8,8 +8,9 @@
 /*
  * Given a filled fiemap structure, extract the struct fiemap_extent
  * which covers the loff offset.
- * If index is not NULL, then it will be filled with the extent's index.
- * If no extent is found, returns NULL and index is garbage.
+ * If index is not NULL, it is used as a hint to start the search and
+ * updated with the found extent's index.
+ * If no extent is found, returns NULL and index is unchanged.
  * The returned value must not be used after fiemap is freed, and must not
  * be freed directly either.
  */


### PR DESCRIPTION
During file scanning, get_extent() was called per-block with a linear scan from index 0. For fragmented files with many extents this made process_blocks and process_extents O(blocks * extents) per file.

Add a cursor hint to get_extent() that lets callers resume the search from where they left off, turning the common forward-scan case into O(blocks + extents). The hint is validated before use so a stale value silently falls back to a full scan.

Co-authored with Claude; improved and verified by me.