### PR TITLE
file_scan and elsewhere: Add option to exclude files below a given size

### DIFF
--- a/duperemove.c
+++ b/duperemove.c
@@ -204,6 +204,7 @@ enum {
 	QUIET_OPTION,
 	EXCLUDE_OPTION,
 	BATCH_SIZE_OPTION,
+	MIN_FILESIZE_OPTION,
 };
 
 static int process_fdupes(void)
@@ -316,6 +317,7 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		{ "quiet", 0, NULL, QUIET_OPTION },
 		{ "exclude", 1, NULL, EXCLUDE_OPTION },
 		{ "batchsize", 1, NULL, BATCH_SIZE_OPTION },
+		{ "min-filesize", 1, NULL, MIN_FILESIZE_OPTION },
 		{ NULL, 0, NULL, 0}
 	};
 
@@ -323,7 +325,7 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		help(); /* Never returns */
 	}
 
-	while ((c = getopt_long(argc, argv, "b:vdDrh?LRqB:", long_ops, NULL))
+	while ((c = getopt_long(argc, argv, "b:vdDrh?LRqBm:", long_ops, NULL))
 	       != -1) {
 		switch (c) {
 		case 'b':
@@ -410,6 +412,15 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		case BATCH_SIZE_OPTION:
 		case 'B':
 			options.batch_size = parse_size(optarg);
+			break;
+		case MIN_FILESIZE_OPTION:
+		case 'm':
+			options.min_filesize = parse_size(optarg);
+			if (options.min_filesize == 0){
+				eprintf("Error: --min-filesize must be "
+					"larger zero\n");
+				return EINVAL;
+			}
 			break;
 		case HELP_OPTION:
 			help();

--- a/file_scan.c
+++ b/file_scan.c
@@ -372,8 +372,8 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 		return false;
 	}
 
-	if (S_ISREG(st->stx_mode) && st->stx_size == 0) {
-		vprintf("Skipping empty file %s\n", path);
+	if (S_ISREG(st->stx_mode) && st->stx_size < options.min_filesize) {
+		vprintf("Skipping too small file %s (is %llu, minimum %lu)\n", path, st->stx_size, options.min_filesize);
 		return false;
 	}
 

--- a/markdown/duperemove.md
+++ b/markdown/duperemove.md
@@ -220,6 +220,10 @@ shells usually expand glob pattern so the passed in pattern ought to also be
 quoted. Taking everything into consideration the correct way to pass an exclusion
 pattern is `duperemove --exclude "/path/to/dir/file*" /path/to/dir`
 
+**-m** `N`, **\--min-filesize**=`N`
+  ~ All files smaller than the given size are excluded from the deduplication process.
+This may speed up things significantly.
+
 # EXAMPLES
 
 ## Simple Usage

--- a/opt.c
+++ b/opt.c
@@ -24,4 +24,5 @@ struct options options = {
 	.dedupe_same_file = true,
 	.batch_size = 1024,
 	.fdupes_mode = false,
+	.min_filesize = 1,
 };

--- a/opt.h
+++ b/opt.h
@@ -15,6 +15,7 @@
 #define	__OPT_H__
 
 #include <stdbool.h>
+#include <stdint.h>
 
 struct options {
 	int run_dedupe;
@@ -27,6 +28,7 @@ struct options {
 	bool dedupe_same_file : 1;
 	unsigned int batch_size;
 	bool fdupes_mode : 1;
+	uint64_t min_filesize;
 	char *hashfile;
 };
 


### PR DESCRIPTION
Add an option --min-filesize=... that causes duperemove to skip all files below the given size.
Should speed things up a lot when there are many tiny files.

Builds fine, doing a first test run (with a 4T hdd) right now.

Closes: https://github.com/markfasheh/duperemove/issues/378