### PR TITLE
File scan: run is_block_zeroed() on the correct block

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -832,7 +832,7 @@ static ssize_t process_blocks(struct scan_ctxt *ctxt, struct buffer *buffer,
 	for (unsigned int i = 0; i < nb_blocks; i++) {
 		if (!is_block_ignored(ctxt->fiemap, curr_file_off) &&
 		    !(options.skip_zeroes &&
-		      is_block_zeroed(buffer->buf + buffer->dl_offset))) {
+		      is_block_zeroed(buffer->buf + i * blocksize))) {
 			ret = process_block(buffer->buf + i * blocksize,
 					    blocksize, curr_file_off, hashes);
 			if (ret)


### PR DESCRIPTION
When using `--skip-zeroes`, we check the wrong block.

We are hashing (using process_block) the block #`i` (at offdset `i * blocksize`), but run `is_block_zeroed()` on
`buffer->buf + buffer->dl_offset`, which is always the same block. The kernel won't damage data since it has its own check, but we basically are uanble to ever dedupe anything correctly here and create pointless work.