### PR TITLE
dedupe: stop instead of spinning when a round makes no progress (#396/#407)

### DIFF
--- a/dedupe.c
+++ b/dedupe.c
@@ -315,6 +315,8 @@ int dedupe_extents(struct dedupe_ctxt *ctxt)
 	int ret = 0;
 
 	while (!list_empty(&ctxt->queued)) {
+		uint64_t round;
+
 		/* Convert the queued list into an actual request */
 		populate_dedupe_request(ctxt, ctxt->same);
 
@@ -332,7 +334,26 @@ retry:
 			goto retry;
 		}
 
+		round = 0;
+		for (unsigned int i = 0; i < ctxt->same->dest_count; i++)
+			round += ctxt->same->info[i].bytes_deduped;
+
 		process_dedupes(ctxt, ctxt->same);
+
+		/*
+		 * Guard against an infinite loop (#396/#407): if a full round
+		 * deduped nothing yet the kernel reported no error, every
+		 * still-queued request just got requeued unchanged. Reissuing
+		 * the identical ioctl would return the same zero, so stop here
+		 * and account the stuck requests as completed instead of
+		 * spinning at 100% CPU forever. Productive dedupe always moves
+		 * >0 bytes per round (a large extent progresses in fs-block
+		 * chunks), so this never cuts real work short.
+		 */
+		if (round == 0 && !list_empty(&ctxt->queued)) {
+			list_splice_init(&ctxt->queued, &ctxt->completed);
+			break;
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
### What this fixes
The dedupe ioctl loop requeues any request the kernel didn't fully finish. If a round deduped **zero** bytes but returned no error (`info[i].status == 0`), every still-queued request was requeued unchanged — and the next identical `FIDEDUPERANGE` returns the same zero. That's an infinite loop.

### What happens without the fix
`duperemove` **hangs**, pinning a CPU core at 100% and never completing the run. It's been reported as hangs on 0.15.x (#396, #407).

### The fix
After each round, sum the bytes deduped. If a full round moved **no** bytes while requests are still queued, stop: splice the stuck requests onto the completed list (accounted as not-deduped) instead of reissuing the same no-op ioctl forever.

Productive dedupe always advances >0 bytes per round — a large extent progresses in fs-block chunks — so this never cuts real work short. Verified a 256 MB extent (8 rounds) still fully shares, and the guard never fired across the integration suite.

Fixes: #396
Fixes: #407
