### PR TITLE
dbfile: avoid "database table is locked" on the in-memory db

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -254,6 +254,21 @@ static int dbfile_set_modes(sqlite3 *db)
 		return ret;
 	}
 
+	/*
+	 * The default (no --hashfile) database is an in-memory shared-cache db
+	 * (see MEMDB_FILENAME) reached over several connections. Shared-cache
+	 * does table-level locking between connections, so a reader holding a
+	 * lock on the files table can make a writer's INSERT fail outright with
+	 * SQLITE_LOCKED ("database table is locked"). read_uncommitted lets
+	 * readers proceed without that lock; it only affects shared-cache mode
+	 * and is a no-op for WAL file-backed hashfiles.
+	 */
+	ret = sqlite3_exec(db, "PRAGMA read_uncommitted = 1", NULL, NULL, NULL);
+	if (ret) {
+		perror_sqlite(ret, "enabling read-uncommitted");
+		return ret;
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
### What this fixes
Without `--hashfile`, `duperemove` uses an in-memory shared-cache database (`file::memory:?cache=shared`) reached over several separate connections. Shared-cache mode does **table-level** locking between connections, so a reader holding a lock on the `files` table can make a concurrent writer's `INSERT` fail outright with `SQLITE_LOCKED` — "database table is locked".

### What happens without the fix
In the default (no-`--hashfile`) mode, the write can fail per file and the run can finish having stored **nothing** — a silent no-op that still exits 0. It tends to go unnoticed because test suites and benchmarks usually pass `--hashfile` (WAL, no shared cache), which isn't affected.

### The fix
Enable `PRAGMA read_uncommitted = 1`, the documented shared-cache mechanism for concurrent reader/writer access: readers no longer take the table lock. It only affects shared-cache mode and is a **no-op for WAL file-backed hashfiles**. The change-detection reads it relaxes are keyed by `(ino, subvol)` and the row is written after the read, so dropping read isolation is safe here.
