### PR TITLE
file_scan: handle sparse files with a trailing hole (#374)

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -887,15 +887,18 @@ static int process_extents(struct scan_ctxt *ctxt, struct buffer *buffer,
 	while (file_off < ctxt->off + bytes) {
 		extent = get_extent(ctxt->fiemap, file_off, NULL);
 		if (!extent) {
-			eprintf("process_extents: unable to get extent\n");
-
-			/* Cleanup the partial checksum and skip
-			 * the rest of the buffer
+			/*
+			 * No extent covers this offset: we've walked past the
+			 * last mapped extent into a trailing hole (data followed
+			 * by a hole up to EOF, which FIEMAP never reports). That
+			 * is not an error - finish the pending checksum and stop
+			 * cleanly. Treating it as a failure made the caller
+			 * declare the file "changed" and never hash or dedupe it.
 			 */
 			if (ctxt->extent_csum)
 				finish_running_checksum(ctxt->extent_csum, NULL);
 			ctxt->extent_csum = NULL;
-			return 1;
+			return 0;
 		}
 
 		ext_end_off = extent->fe_logical + extent->fe_length;
@@ -929,7 +932,8 @@ static int process_extents(struct scan_ctxt *ctxt, struct buffer *buffer,
 		 * the part that will never exist.
 		 */
 		size_t dummy = 0;
-		if (extent->fe_flags & FIEMAP_EXTENT_LAST)
+		if ((extent->fe_flags & FIEMAP_EXTENT_LAST) &&
+		    ext_end_off > ctxt->filesize)
 			dummy = ext_end_off - ctxt->filesize;
 		if (file_off + dummy == ext_end_off) {
 			ret = store_extent(ctxt, hashes, extent);


### PR DESCRIPTION
### What this fixes
A file whose data ends before EOF (data followed by a hole up to end-of-file) has a last mapped extent that ends *before* `filesize`; FIEMAP never reports the trailing hole. `process_extents()` then broke in two ways once `file_off` reached the hole:

- `dummy = ext_end_off - filesize` **underflowed** (`size_t`), because the last extent ends before `filesize`, so `file_off + dummy == ext_end_off` never held and the last real extent was never stored;
- the next `get_extent()` returned `NULL`, which printed `process_extents: unable to get extent` and returned 1, so the caller declared the file "changed" and abandoned it.

### What happens without the fix
Any file with a trailing hole is **silently never hashed or deduped** — it's skipped every run.

### The fix
Only subtract the past-EOF overshoot when the extent actually runs past `filesize`, and treat a `NULL` from `get_extent()` as "past the last extent = trailing hole, stop cleanly" rather than an error. Verified that trailing-, middle- and leading-hole files all scan and dedupe with data preserved byte-for-byte.

(Originally filed as broken compressed-FS handling, but compression maps fine on current kernels — logical offsets/lengths with the ENCODED flag — the real trigger is the trailing hole.)

Fixes: #374
