### PR TITLE
file_scan: skip hardlinks in --fdupes instead of aborting (#389)

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -1258,5 +1258,17 @@ void add_file_fdupes(char *path)
 		eprintf("statx on %s: %s\n", path, strerror(errno));
 		return;
 	}
+
+	/*
+	 * Filerecs are keyed by inode. Two hardlinks in the same fdupes group
+	 * would produce a duplicate key and abort in insert_filerec(). They
+	 * already share storage, so deduping them is pointless anyway - skip
+	 * any inode we've already listed.
+	 */
+	if (filerec_find(st.stx_ino)) {
+		vprintf("Skipping %s: hardlink to an already-listed file\n",
+			path);
+		return;
+	}
 	filerec_new(path, st.stx_ino, st.stx_size);
 }


### PR DESCRIPTION
### What this fixes
Filerecs are keyed by inode. Two hard links to the same inode in a single `--fdupes` group produce the same key and trip the "should never happen" abort in `insert_filerec()`.

### What happens without the fix
`duperemove --fdupes` **core-dumps the entire run** when the input list contains two or more hard links to the same file.

### The fix
Hard links already share storage, so deduping them is pointless anyway — skip any inode already listed. The regular scan path already has an equivalent guard; `--fdupes` simply lacked one.

Fixes: #389
