### PR TITLE
dbfile: fix use-after-free and leak when recreating a rejected hashfile

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -257,8 +257,9 @@ static int dbfile_set_modes(sqlite3 *db)
 	return ret;
 }
 
-static int dbfile_prepare(sqlite3 *db)
+static int dbfile_prepare(sqlite3 **db_p)
 {
+	sqlite3 *db = *db_p;
 	struct dbfile_config cfg;
 	int ret;
 	char dbpath[PATH_MAX + 1];
@@ -306,8 +307,18 @@ static int dbfile_prepare(sqlite3 *db)
 			return ret;
 		}
 
+		/*
+		 * Hand the freshly-opened handle back to the caller:
+		 * dbfile_prepare took *db_p by reference precisely so this
+		 * replacement propagates. The old handle was just closed above;
+		 * returning it (as the by-value version did) left the caller
+		 * using freed memory and leaking this new one.
+		 */
 		db = __dbfile_open_handle(dbpath, false);
-		return dbfile_prepare(db);
+		*db_p = db;
+		if (!db)
+			return -1;
+		return dbfile_prepare(db_p);
 	}
 
 	/* May store the default config, if fields were missing
@@ -359,7 +370,7 @@ static sqlite3 *__dbfile_open_handle(char *filename, bool force_create)
 		return NULL;
 	}
 
-	ret = dbfile_prepare(db);
+	ret = dbfile_prepare(&db);
 	if (ret) {
 		sqlite3_close(db);
 		return NULL;


### PR DESCRIPTION
### What this fixes
When an existing hashfile fails `dbfile_check()` (a schema-version or hash-type mismatch — e.g. opening an older hashfile with a newer `duperemove`), `dbfile_prepare()` takes the "Recreating hashfile" path: it `sqlite3_close()`s the handle, unlinks the file, reopens a fresh one, and recurses.

But the handle was passed **by value**, so the reopened handle only ever lived in `dbfile_prepare()`'s local variable. Its caller, `__dbfile_open_handle()`, kept — and returned — a pointer to the *closed* handle.

### What happens without the fix
`__dbfile_open_handle()`'s caller then runs `sqlite3_prepare_v2()` on that freed handle — a **use-after-free** (`SQLITE_MISUSE` / "Database error 21") — and later `sqlite3_close()`s it a second time, while the real working handle opened during recreation is **leaked** (~160 KB, "definitely lost" under valgrind). Normal runs happen to read the freed-but-intact memory and pass, so it's a latent defect; valgrind surfaces it reliably whenever a hashfile is rebuilt.

### The fix
Pass the handle by reference (`sqlite3 **`) so the freshly-opened handle propagates back to the caller, and bail out cleanly if the reopen fails (the previous code would also have recursed into `dbfile_prepare(NULL)`).

Found via valgrind in the `oans` fork, whose strict hashfile branding makes the recreate path easy to hit — but the defect is inherited straight from here.
