### PR TITLE
dbfile: zero-initialise the uuid buffer in __dbfile_get_config

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -863,7 +863,13 @@ static int get_config_text(sqlite3_stmt *stmt, const char *name, char *val, int 
 static int __dbfile_get_config(sqlite3 *db, struct dbfile_config *cfg)
 {
 	int ret;
-	char uuid[37]; /* 36-bytes uuid + \0 */
+	/*
+	 * Zero-initialised so the buffer is always NUL-terminated: get_config_text
+	 * memcpy()s exactly `len` (36) bytes without terminating, and if the
+	 * config row is absent it writes nothing at all - either way uuid_parse()
+	 * below would otherwise strlen() past uninitialised bytes.
+	 */
+	char uuid[37] = "";	/* 36-byte uuid + NUL */
 	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
 
 #define SELECT_CONFIG "select keyval from config where keyname=?1;"


### PR DESCRIPTION
### What this fixes
`__dbfile_get_config()` declares `char uuid[37];` uninitialised, then fills it via `get_config_text(stmt, "fs_uuid", uuid, 36)`. `get_config_text()` `memcpy()`s exactly `len` (36) bytes **without** writing a NUL terminator — and writes **nothing at all** if the `fs_uuid` config row is absent. It then calls `uuid_parse(uuid, ...)`, which `strlen()`s its argument.

### What happens without the fix
`uuid_parse()`'s `strlen()` runs past the 36-byte uuid into **uninitialised stack** (an uninitialised read — valgrind flags it on every config load). If the `fs_uuid` row is missing, the whole buffer is uninitialised and `uuid_parse()` can parse garbage over the default `fs_uuid`. In practice the trailing stack bytes are usually zero, so it silently "works" — but it's undefined behaviour.

### The fix
Zero-initialise the buffer (`char uuid[37] = "";`) so it is always NUL-terminated regardless of what `get_config_text()` wrote.

Found via a valgrind sweep in the `oans` fork; the defect is inherited straight from here.
